### PR TITLE
Use serialize.h::VarInt for encoding

### DIFF
--- a/bip-annex.mediawiki
+++ b/bip-annex.mediawiki
@@ -1,0 +1,123 @@
+<pre>
+  BIP: XXX
+  Layer: Consensus (soft fork)
+  Title: Taproot Annex Format
+  Author:
+  Comments-Summary: No comments yet.
+  Comments-URI:
+  Status: Draft
+  Type: Standards Track
+  Created:
+  License: BSD-3-Clause
+  Requires: 340, 341, 342
+</pre>
+
+== Introduction ==
+
+=== Abstract ===
+
+This BIP describes a validation format for the taproot annex ([https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki BIP341]).
+It allows to extend the usual transaction fields with new data records allowing witness signatures to commit to them.
+The data records can be subject to new validation rules.
+
+=== Copyright ===
+
+This document is licensed under the 3-clause BSD license.
+
+=== Motivation ===
+
+From the limited set of Bitcoin transaction fields (i.e nVersion, inputs, outputs, nLocktime, etc)
+released in the early days of the network, few soft-forks occurred extending the validation semantic
+of some transaction fields (e.g [https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki BIP68])
+or adding whole new field to solve the malleability issue (e.g [https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki BIP141]). 
+While a generic mechanism consensusparamsto extend the block commmitments have been provisioned with BIP141, 
+there is lacking an equivalent generic mechanism to extend the transaction data fields.
+
+This proposal introduces a format to add new data fields in the Taproot annex. BIP341 mandates
+that if a witness includes at least two elements and the first byte of the last element is 0x50,
+this element is qualified as the annex. The remaining bytes semantics are defined by new validation
+rules following a Type-Length-Value format.
+
+Specific semantics for the new data fields can be introduced with future soft-forks to enable a range
+of use-cases. For now there is only one nLocktime field in a transaction and all inputs must share
+the same value. It could be possible to define per-input lock-time enabling aggregation of off-chain
+protocols transactions (e.g [https://github.com/lightning/bolts/blob/master/03-transactions.md#htlc-timeout-and-htlc-success-transactions Lightning HTLC-timeout]).
+A commitment to historical block hash could be also a new annex data field to enable replay protection
+in case of persisting forks. Another use-case, a group of input-outputs could be bundled and signed
+together to enable fee-bumping batching of off-chain protocols transactions. <ref> '''What if the
+use-cases require access to the annex fields by Script operations ?''' A new PUSH_ANNEX_RECORD could be
+defined to make accessible annex fields to Script operations. </ref> Beyond, the annex format aims to
+be reusable across spends of SegWit versions.
+
+== Specification ==
+
+=== Type-Length-Value Format ===
+
+A TLV (Type-Length-Value) format is used to allow for the backwards-compatible addition of new fields
+to the annex.
+
+A `tlv_record` represents a single annex field, encoded in the form:
+* `VarInt` | 1-byte `RecordLowerBitMask`: `type`
+* `VarInt`: length
+* `length`: value
+
+The `type` is encoded using the VarInt format <ref>'''Why using VarInt''' In practice, chances are the record
+value to be small following power law distribution. So if the small values can be stored in fewer bytes,
+that's a saving. </ref> and a 1-byte `RecordLowerMask`.
+
+The `length` is encoded using the VarInt format signaling the size of `value` in bytes.
+
+The value depends entirely on the `type` and should be encoded or decoded according to the annex record
+specific format determined by `type`.
+
+=== Annex parsing rules ===
+
+* The first byte of the annex is popped.
+* While the annex bytes stream is not empty:
+** VarInt-bytes are read from the annex bytes stream and stored in a uint64_t RecordHigherMask.
+** 1-byte is read from the annex bytes stream and stored in a uint8_t RecordLowerMask.
+** Let RecordType defined as: RecordHigherMask * 64 + (RecordLowerMask & 0x3F).
+** If (RecordLowerMask & 0xc0) == 0:
+*** VarInt-bytes are read from the annex and stored in a uint64_t RecordLength.
+*** RecordLength is incremented by 3.
+** Else:
+*** Let RecordLength defined as: ((RecordLowerMask & 0xc0) >> 6).
+** RecordLength is read from the annex bytes stream and stored in char vector RecordValue.
+
+TODO: how much low-level should be the description of the annex parsing rules ?
+
+=== Annex validation rules ===
+
+* If the annex bytes stream is lower than RecordLength, fail the validation.
+* If the annex type is invalid following the type validation semantics defined in future softforks, fail the validation.
+
+== Security ==
+
+=== DoSy annex ===
+
+Lengthy annex bytes stream could be given to nodes as a CPU DoS vector. Standard policy
+rules should be adequate to prevent that concern.
+
+If many annex fields are considered as valid, a compensation mechanism should be
+introduced to constrain witness producer to commit higher fees (e.g inflate witness
+weight in function of annex size).
+
+== Rationale ==
+
+<references />
+
+== Reference Implementation ==
+
+https://github.com/ariard/bitcoin/commits/2022-06-annex-format
+
+== Deployment ==
+
+
+== Backwards compatibility ==
+
+
+== Revisions ==
+
+== Acknowledgements ==
+
+Thanks to AJ Towns for originating many of the ideas in this BIP.

--- a/bip-annex.mediawiki
+++ b/bip-annex.mediawiki
@@ -36,7 +36,7 @@ there is lacking an equivalent generic mechanism to extend the transaction data 
 This proposal introduces a format to add new data fields in the Taproot annex. BIP341 mandates
 that if a witness includes at least two elements and the first byte of the last element is 0x50,
 this element is qualified as the annex. The remaining bytes semantics are defined by new validation
-rules following a Type-Length-Value format.
+rules following a highly byte efficient Type-Length-Value format.
 
 Specific semantics for the new data fields can be introduced with future soft-forks to enable a range
 of use-cases. For now there is only one nLocktime field in a transaction and all inputs must share
@@ -51,45 +51,101 @@ be reusable across spends of SegWit versions.
 
 == Specification ==
 
+=== CompressedInt Integer Encoding ===
+
+Variable-length integers: bytes are a MSB base-128 encoding of the number.
+The high bit in each byte signifies whether another digit follows. To make
+sure the encoding is one-to-one, one is subtracted from all but the last digit.
+Thus, the byte sequence a[] with length len, where all but the last byte
+has bit 128 set, encodes the number:
+
+  (a[len-1] & 0x7F) + sum(i=1..len-1, 128^i*((a[len-i-1] & 0x7F)+1))
+
+Properties:
+ * Very small (0-127: 1 byte, 128-16511: 2 bytes, 16512-2113663: 3 bytes)
+ * Every integer has exactly one encoding
+ * Encoding does not depend on size of original integer type
+ * No redundancy: every (infinite) byte sequence corresponds to a list
+   of encoded integers.
+
+Examples:
+ * 0:         [0x00]  256:        [0x81 0x00]
+ * 1:         [0x01]  16383:      [0xFE 0x7F]
+ * 127:       [0x7F]  16384:      [0xFF 0x00]
+ * 128:  [0x80 0x00]  16511:      [0xFF 0x7F]
+ * 255:  [0x80 0x7F]  65535: [0x82 0xFE 0x7F]
+ * 2^32:           [0x8E 0xFE 0xFE 0xFF 0x00]
+
+ read_CompressedInt():
+     result = 0
+     while not eof():
+         b = read_bytes(1)
+         if b < 128: return result + b
+         result += b - 127
+         result *= 128
+     fail()
+
+ write_CompressedInt(n):
+     out = []
+     while True:
+         out.append( n % 128 )
+         if n <= 127: break
+         n = (n // 128) - 1
+     while len(out) > 1:
+         write(out.pop() | 0x80)
+     write(out.pop())
+
 === Type-Length-Value Format ===
 
-A TLV (Type-Length-Value) format is used to allow for the backwards-compatible addition of new fields
-to the annex.
+The annex is defined as containing an ordered set of "type, value" pairs, where the type is a non-negative integer, and the value is a byte stream, and the pairs are listed in non-decreasing order by type.
 
-A `tlv_record` represents a single annex field, encoded in the form:
-* `VarInt` | 1-byte `RecordLowerBitMask`: `type`
-* `VarInt`: length
-* `length`: value
+The annex is encoded as follows:
 
-The `type` is encoded using the VarInt format <ref>'''Why using VarInt''' In practice, chances are the record
-value to be small following power law distribution. So if the small values can be stored in fewer bytes,
-that's a saving. </ref> and a 1-byte `RecordLowerMask`.
+ write(0x50)
+ last_type = 0
+ for type, value in annex:
+    delta = type - last_type
+    assert delta >= 0, "annex must be ordered by type"
+    if length(value) < 127:
+        write_CompressedInt(delta * 128 + length(value))
+    else:
+        write_CompressedInt(delta * 128 + 127)
+        write_CompressedInt(length(value) - 127)
+    write(value)
+    last_type = type
 
-The `length` is encoded using the VarInt format signaling the size of `value` in bytes.
+And conversely the annex may be decoded as follows:
 
-The value depends entirely on the `type` and should be encoded or decoded according to the annex record
-specific format determined by `type`.
+ assert read_bytes(1) == 0x50, "annex must begin with annex marker"
+ last_type = 0
+ annex = []
+ while not eof():
+    deltalen = read_CompressedInt()
+    type = last_type + (deltalen >> 7)
+    length = deltalen & 0x7F
+    if length == 0x7F:
+        length += read_CompressedInt()
+    value = read_bytes(length)
+    annex.append( (type, value) )
+    last_type = type
 
-=== Annex parsing rules ===
+Rather than encoding the type directly, we encode the difference between
+the previous type (initially 0), both minimising the encoding and ensuring
+a canonical ordering for annex entries.
 
-* The first byte of the annex is popped.
-* While the annex bytes stream is not empty:
-** VarInt-bytes are read from the annex bytes stream and stored in a uint64_t RecordHigherMask.
-** 1-byte is read from the annex bytes stream and stored in a uint8_t RecordLowerMask.
-** Let RecordType defined as: RecordHigherMask * 64 + (RecordLowerMask & 0x3F).
-** If (RecordLowerMask & 0xc0) == 0:
-*** VarInt-bytes are read from the annex and stored in a uint64_t RecordLength.
-*** RecordLength is incremented by 3.
-** Else:
-*** Let RecordLength defined as: ((RecordLowerMask & 0xc0) >> 6).
-** RecordLength is read from the annex bytes stream and stored in char vector RecordValue.
+If length(value) is between 0 and 126 bytes, then:
+* entries with delta=0 are encoded in 1+length(value) bytes
+* entries with delta=1..128 are encoded in 2+length(value) bytes
+* entries with delta=129..16512 are encoded in 3+length(value) bytes
 
-TODO: how much low-level should be the description of the annex parsing rules ?
+The meaning of the value byte stream depends entirely on the `type` and may require further encoding/deconding as appropriate.
 
 === Annex validation rules ===
 
-* If the annex bytes stream is lower than RecordLength, fail the validation.
+* If the annex does not decode successfully (that is, if read_CompressedInt() or read_bytes(length) fail due to reaching eof early); fail.
 * If the annex type is invalid following the type validation semantics defined in future softforks, fail the validation.
+
+Additionally, care should be taken to not fail on potential overflow either in read_CompressedInt() or when cacluating `last_type + (deltalen >> 7)`.
 
 == Security ==
 


### PR DESCRIPTION
Here's what I've been thinking of... It has two main differences: it encodes the type as a delta, which enforces a canonical encoding (lowest types go first), and it's slightly more compressed.

I think what you've currently got encodes:

 * type = `[0, 2**14)`, length(value) = 1,2,3 -- 2 bytes + length(value)
 * type = `[0, 2**14)`, length(value) = 0 or [4,253] -- 3 bytes + length(value)

I guess I find the "enforce canonical ordering by encoding as types as a delta" the most compelling part.

I found the `RecordLowerBitMask` stuff hard to follow as it's currently explained, fwiw.

...

Alternatively, perhaps doing a custom encoding with VarInt would be both clear and fine:

```
x = read_bytes(1)
y = read_VarInt()
type = last_type + (y << 6) + (x >> 2)
size = x & 0x3
if size == 3: size += read_VarInt()
value = read_bytes(size)
```

So your encoding is always:

 * base_type_size : 1 byte (6 bits for type, 2 bits for size)
 * extended_type : VarInt
 * extended_size : optional VarInt (type_size & 3 == 3)
 * value : size

That's still pretty compressed, and gives a canonical encoding/ordering...